### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Cal Server
 [![smithery badge](https://smithery.ai/badge/@pwh-pwh/cal-mcp)](https://smithery.ai/server/@pwh-pwh/cal-mcp)
 
+<a href="https://glama.ai/mcp/servers/@pwh-pwh/cal-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pwh-pwh/cal-mcp/badge" alt="Cal Server MCP server" />
+</a>
+
 ## 项目简介
 
 `Cal Server` 是一个基于 `FastMCP` 框架构建的简单数学表达式计算服务，使用 Bun 运行时环境。它利用 `expr-eval` 库解析和计算用户输入的数学表达式，并通过标准输入输出（stdio）与外界交互。该项目旨在提供一个轻量、高效的计算工具，支持基本数学运算和内置常量。
@@ -74,8 +78,6 @@ npx -y @smithery/cli install @pwh-pwh/cal-mcp --client claude
     - 基本运算：`2 + 2` → `4`
     - 使用常量：`PI * 2` → `6.283185307179586`
     - 复杂表达式：`E ^ 2 + 1` → `8.38905609893065`
-
-
 
 ## 注意事项
 


### PR DESCRIPTION
This PR adds a badge for the [Cal Server](https://glama.ai/mcp/servers/@pwh-pwh/cal-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@pwh-pwh/cal-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@pwh-pwh/cal-mcp/badge" alt="Cal Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.